### PR TITLE
try/except around decode

### DIFF
--- a/resources/openGOALModLauncher.py
+++ b/resources/openGOALModLauncher.py
@@ -63,12 +63,15 @@ def show_progress(block_num, block_size, total_size):
 
 def process_exists(process_name):
     call = 'TASKLIST', '/FI', 'imagename eq %s' % process_name
-    # use buildin check_output right away
-    output = subprocess.check_output(call).decode()
-    # check in last line for process name
-    last_line = output.strip().split('\r\n')[-1]
-    # because Fail message could be translated
-    return last_line.lower().startswith(process_name.lower())
+    try:
+        # use buildin check_output right away
+        output = subprocess.check_output(call).decode()
+        # check in last line for process name
+        last_line = output.strip().split('\r\n')[-1]
+        # because Fail message could be translated
+        return last_line.lower().startswith(process_name.lower())
+    except:
+        return False
 
 def try_kill_process(process_name):
 	if process_exists(process_name):


### PR DESCRIPTION
if it throws exception then probably it was the generic task not found message with non-utf8 chars, so just return false.